### PR TITLE
Initialize basic Hugo site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/public/
+/resources/
+/hugo_cache/
+.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# kazumbah
+# Kazumbah Hugo Site
+
+This repository contains a minimal [Hugo](https://gohugo.io/) website designed to be deployed via a Cloudflare Worker or Pages project.
+
+## Local development
+
+1. Install the extended version of Hugo.
+2. Build the site locally:
+
+   ```bash
+   hugo server
+   ```
+
+   The generated site is served from `http://localhost:1313`.
+
+## Cloudflare deployment
+
+When configuring the Cloudflare Worker/Pages project:
+
+- **Build command:** `hugo`
+- **Build output directory:** `public`
+- **Environment variables:**
+  - `HUGO_VERSION`: `0.123.7` (or your preferred version)
+  - `NODE_VERSION`: `20` (needed for Hugo Pipes when using PostCSS/Sass)
+
+These settings ensure Cloudflare installs the correct Hugo binary and outputs the generated site to the `public` directory.

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Home"
+---
+
+Welcome to my new Hugo site hosted on Cloudflare Workers!
+

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,4 @@
+baseURL = 'https://example.org/'
+languageCode = 'en-us'
+title = 'My New Hugo Site'
+theme = 'mytheme'

--- a/themes/mytheme/layouts/_default/baseof.html
+++ b/themes/mytheme/layouts/_default/baseof.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{ .Title }}</title>
+</head>
+<body>
+  {{ block "main" . }}{{ end }}
+</body>
+</html>

--- a/themes/mytheme/layouts/index.html
+++ b/themes/mytheme/layouts/index.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+  {{ .Content }}
+{{ end }}

--- a/themes/mytheme/theme.toml
+++ b/themes/mytheme/theme.toml
@@ -1,0 +1,3 @@
+name = 'mytheme'
+license = 'MIT'
+licenselink = 'https://opensource.org/licenses/MIT'


### PR DESCRIPTION
## Summary
- scaffold minimal Hugo website with custom `mytheme`
- add home page content and basic layout
- document Cloudflare deployment settings

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c0281375308325b5a3ff4f382e231e