### PR TITLE
Fix broken service pages by adding layouts and correct base URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://kazumbah.example.com/'
+baseURL = 'https://kazumbah.com.au/'
 languageCode = 'en-au'
 title = 'Kazumbah Zumba with Kaz in Murwillumbah'
 theme = 'mytheme'

--- a/themes/mytheme/layouts/_default/list.html
+++ b/themes/mytheme/layouts/_default/list.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+  {{ .Content }}
+  <ul>
+    {{ range .Pages }}
+      <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/themes/mytheme/layouts/_default/single.html
+++ b/themes/mytheme/layouts/_default/single.html
@@ -1,0 +1,4 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+{{ end }}


### PR DESCRIPTION
## Summary
- Add single and list templates so service and location pages build correctly
- Update base URL to use the kazumbah.com.au domain

## Testing
- `hugo -d public`

------
https://chatgpt.com/codex/tasks/task_e_68c02f3dd5a083258639866030261042