### PR TITLE
Add sticky header, CTA, and footer contact info

### DIFF
--- a/themes/mytheme/layouts/_default/baseof.html
+++ b/themes/mytheme/layouts/_default/baseof.html
@@ -3,8 +3,33 @@
 <head>
   <meta charset="utf-8">
   <title>{{ .Title }}</title>
+  <style>
+    body { margin:0; font-family: sans-serif; }
+    header { position: sticky; top:0; background:#fff; padding:10px 20px; box-shadow:0 2px 4px rgba(0,0,0,0.1); z-index:1000; }
+    nav a { margin-right:15px; text-decoration:none; color:#333; }
+    nav a.cta { background:#f04; color:#fff; padding:5px 10px; border-radius:4px; }
+    main { padding:20px; }
+    .cta-section { text-align:center; padding:2rem 1rem; background:#f9f9f9; }
+    .cta-section a { background:#f04; color:#fff; padding:10px 20px; text-decoration:none; border-radius:4px; }
+    footer { background:#333; color:#fff; text-align:center; padding:1rem; }
+    footer a { color:#fff; }
+  </style>
 </head>
 <body>
-  {{ block "main" . }}{{ end }}
+  <header>
+    <nav>
+      <a href="{{ "/locations/" | relURL }}">Locations</a>
+      <a href="{{ "/services/" | relURL }}">Classes</a>
+      <a href="{{ "/book-a-class/" | relURL }}" class="cta">Book a Class</a>
+    </nav>
+  </header>
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+  {{ partial "cta.html" . }}
+  <footer>
+    <p>&copy; {{ now.Year }} {{ .Site.Params.owner }} | <a href="tel:{{ replace .Site.Params.phone " " "" }}">{{ .Site.Params.phone }}</a></p>
+    <p><a href="{{ .Site.Params.facebook }}">Facebook</a></p>
+  </footer>
 </body>
 </html>

--- a/themes/mytheme/layouts/partials/cta.html
+++ b/themes/mytheme/layouts/partials/cta.html
@@ -1,0 +1,4 @@
+<section class="cta-section">
+  <h2>Ready to dance?</h2>
+  <a href="{{ "/book-a-class/" | relURL }}">Book a Class</a>
+</section>


### PR DESCRIPTION
## Summary
- Add sticky header with navigation links to locations, classes, and book-a-class pages.
- Introduce site-wide "Book a Class" call-to-action section.
- Implement footer showing owner, phone, and Facebook contact info.

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c0332b6a8c8325a3c7908111f68547