### PR TITLE
Add sitewide background video

### DIFF
--- a/themes/mytheme/layouts/_default/baseof.html
+++ b/themes/mytheme/layouts/_default/baseof.html
@@ -14,10 +14,34 @@
     footer { background:#333; color:#fff; text-align:center; padding:1rem; }
     footer a { color:#fff; }
     footer iframe { max-width:100%; }
+    #bg-video {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      filter: blur(8px);
+      z-index: -2;
+    }
+    .video-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(255,255,255,0.6);
+      z-index: -1;
+      pointer-events: none;
+    }
   </style>
   {{ partial "schema.html" . }}
 </head>
 <body>
+  <video id="bg-video" autoplay muted loop playsinline>
+    <source src="https://videos.pexels.com/video-files/8956012/8956012-hd_1920_1080_25fps.mp4" type="video/mp4">
+  </video>
+  <div class="video-overlay"></div>
   <header>
     <nav>
       <a href="{{ "/locations/" | relURL }}">Locations</a>


### PR DESCRIPTION
## Summary
- Embed Pexels video as a full-site background
- Add blur and semi-transparent white overlay for readability

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68c0ded806a88325989f842ccdaca09d