### PR TITLE
style: apply new fonts and brand color

### DIFF
--- a/themes/mytheme/layouts/_default/baseof.html
+++ b/themes/mytheme/layouts/_default/baseof.html
@@ -4,16 +4,21 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ .Title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Zandes&display=swap" rel="stylesheet">
   <style>
-    body { margin:0; font-family: sans-serif; }
+    body { margin:0; font-family: 'Inter', sans-serif; }
+    h1, h2, h3, h4, h5, h6 { font-family: 'Zandes', sans-serif; }
+    a { color:#BE2D93; }
     header { position: sticky; top:0; background:#fff; padding:10px 20px; box-shadow:0 2px 4px rgba(0,0,0,0.1); z-index:1000; }
-    nav a { margin-right:15px; text-decoration:none; color:#333; }
-    nav a.cta { background:#f04; color:#fff; padding:5px 10px; border-radius:4px; }
+    nav a { margin-right:15px; text-decoration:none; color:#BE2D93; }
+    nav a.cta { background:#BE2D93; color:#fff; padding:5px 10px; border-radius:4px; }
     main { padding:20px; }
     .cta-section { text-align:center; padding:2rem 1rem; background:#f9f9f9; }
-    .cta-section a { background:#f04; color:#fff; padding:10px 20px; text-decoration:none; border-radius:4px; }
+    .cta-section a { background:#BE2D93; color:#fff; padding:10px 20px; text-decoration:none; border-radius:4px; }
     footer { background:#333; color:#fff; text-align:center; padding:1rem; }
-    footer a { color:#fff; }
+    footer a { color:#BE2D93; }
     footer iframe { max-width:100%; }
     #bg-video {
       position: fixed;


### PR DESCRIPTION
## Summary
- Use Inter as the base font and Zandes for headings
- Switch CTA buttons and links to the brand color #BE2D93

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68c0e21a041483259958ac17f4587220